### PR TITLE
ci: build esp32s3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Need to add xtensa-espressif_esp32s3_zephyr-elf toolchain to docker image
-          # - manifest:    west.yml
-          #   board:       esp32s3_devkitm
-          #   binary_blob: hal_espressif
+          - manifest:    west.yml
+            board:       esp32s3_devkitm
+            binary_blob: hal_espressif
           - manifest:    west.yml
             board:       mimxrt1024_evk
           - manifest:    west-ncs.yml


### PR DESCRIPTION
Now that the docker image has been updated to contain the esp32s3 toolchain, we can build for that devkit in CI.