### PR TITLE
Update the Memfault SDK to v1.9.4

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -34,7 +34,7 @@ manifest:
 
     - name: memfault-firmware-sdk
       path: deps/modules/lib/memfault-firmware-sdk
-      revision: 1.9.3
+      revision: 1.9.4
       remote: memfault
 
   self:


### PR DESCRIPTION
Needed to insert a Memfault Build ID to the output ELF for non-mcuboot
ESP32 Zephyr projects (esptool.py doesn't support GNU Build IDs).
